### PR TITLE
Fix / workaround for multi-level folder unity projects

### DIFF
--- a/Editor/Scripts/GitLocksObject.cs
+++ b/Editor/Scripts/GitLocksObject.cs
@@ -1,6 +1,7 @@
 // <copyright file="GitLocksObject.cs" company="Tom Duchene and Tactical Adventures">All rights reserved.</copyright>
 
 using System;
+using System.Runtime.Serialization;
 using UnityEditor;
 
 [System.Serializable]
@@ -24,7 +25,7 @@ public class GitLocksObject
         }
         else
         {
-            this.objectRef = AssetDatabase.LoadMainAssetAtPath(this.path);
+            this.objectRef = AssetDatabase.LoadMainAssetAtPath(path);
             return this.objectRef;
         }
     }
@@ -40,6 +41,20 @@ public class GitLocksObject
         string r = dt.ToShortDateString() + " - " + dt.ToShortTimeString();
         return r;
     }
+
+    [OnDeserialized]
+    internal void OnDeserializedMethod(StreamingContext context)
+    {
+        path = FindRelativePath("Assets");
+    }
+
+    private string FindRelativePath(string relativeFolder)
+    {
+        int index = path.IndexOf(relativeFolder, StringComparison.OrdinalIgnoreCase);
+        if (index != -1) return path.Substring(index);
+        else return path;
+    }
+
 }
 
 public class LockedObjectOwner


### PR DESCRIPTION
Borrowed from "Chronicbite" via https://github.com/TomDuchene/unity-git-locks/issues/1#issue-1837906490.
Please see the original issue at: https://github.com/TomDuchene/unity-git-locks/issues/1.

FWIW, I've tried to split this up in an "assetPath" and the git "path". 
However, the path was being used in both as relative and "absolute" all over the place.