### PR TITLE
Fixed git-locks from updating when entering PlayMode

### DIFF
--- a/Editor/Scripts/GitLocks.cs
+++ b/Editor/Scripts/GitLocks.cs
@@ -904,7 +904,7 @@ public class GitLocks : ScriptableObject
 
     private static void Update()
     {
-        if (!IsEnabled() || EditorApplication.isUpdating || EditorApplication.isCompiling)
+        if (!IsEnabled() || EditorApplication.isUpdating || EditorApplication.isCompiling || EditorApplication.isPlaying)
         {
             return; // Early return if the whole tool is disabled of if the Editor is not available
         }


### PR DESCRIPTION
Which was causing a lag spike of ~300ms after entering PlayMode.
It basically tried to build the "uncommitted cache", presumably triggered by `OnSaveAssets*` being called when entering play mode.