### PR TITLE
Allow locking/unlocking scenes in hierarchy from context menu + bugfix

### DIFF
--- a/Editor/Scripts/GitLocks.cs
+++ b/Editor/Scripts/GitLocks.cs
@@ -847,7 +847,7 @@ public class GitLocks : ScriptableObject
         foreach (string branch in branchesToCheck)
         {
             // Fetch
-            ExecuteProcessTerminal("git", "git fetch origin " + branch);
+            ExecuteProcessTerminal("git", "fetch origin " + branch);
 
             // List all distant commits
             string output = ExecuteProcessTerminal("git", "rev-list " + currentBranch + "..origin/" + branch);


### PR DESCRIPTION
♦ Allow locking/unlocking scenes in hierarchy window from context menu (right click on scene header -> GameObject -> Git LFS Lock)
♦ fixed bug that caused "fetch" to not work when locking files