### PR TITLE
Allow explicitly configuring git binary paths

### DIFF
--- a/Editor/Scripts/GitLocks.cs
+++ b/Editor/Scripts/GitLocks.cs
@@ -122,7 +122,7 @@ public class GitLocks : ScriptableObject
 
         // Get the locks asynchronously
         currentlyRefreshing = true;
-        ExecuteNonBlockingProcessTerminal("git", "lfs locks --json");
+        ExecuteNonBlockingProcessTerminal(GetGitLfsPath(), "locks --json");
     }
 
     public static void RefreshCallback(string result)
@@ -130,7 +130,7 @@ public class GitLocks : ScriptableObject
         // If empty result, start a simple git lfs locks (no json) to catch potential errors
         if (result == "[]")
         {
-            ExecuteNonBlockingProcessTerminal("git", "lfs locks");
+            ExecuteNonBlockingProcessTerminal(GetGitLfsPath(), "locks");
         }
 
         // Check that we're receiving what seems to be a JSON result
@@ -549,7 +549,7 @@ public class GitLocks : ScriptableObject
         // Send each request
         foreach (string pathsString in pathsStrings)
         {
-            ExecuteProcessTerminalWithConsole("git", "lfs lock " + pathsString);
+            ExecuteProcessTerminalWithConsole(GetGitLfsPath(), "lock " + pathsString);
         }
     }
 
@@ -585,7 +585,7 @@ public class GitLocks : ScriptableObject
         // Send each request
         foreach (string pathsString in pathsStrings)
         {
-            ExecuteProcessTerminalWithConsole("git", "lfs unlock " + pathsString + (force ? "--force" : string.Empty));
+            ExecuteProcessTerminalWithConsole(GetGitLfsPath(), "unlock " + pathsString + (force ? "--force" : string.Empty));
         }
     }
 
@@ -663,11 +663,23 @@ public class GitLocks : ScriptableObject
         return EditorPrefs.GetString("gitLocksHostUsername", string.Empty);
     }
 
+    public static string GetGitPath()
+    {
+        string path = EditorPrefs.GetString("gitLocksGitPath", "git");
+        return string.IsNullOrEmpty(path) ? "git" : path;
+    }
+
+    public static string GetGitLfsPath()
+    {
+        string path = EditorPrefs.GetString("gitLocksGitLfsPath", "git lfs");
+        return string.IsNullOrEmpty(path) ? "git lfs" : path;
+    }
+
     public static string GetGitVersion()
     {
         if (gitVersion == null || gitVersion == string.Empty)
         {
-            gitVersion = ExecuteProcessTerminalWithConsole("git", "--version");
+            gitVersion = ExecuteProcessTerminalWithConsole(GetGitPath(), "--version");
         }
 
         return gitVersion;
@@ -785,12 +797,12 @@ public class GitLocks : ScriptableObject
         char[] splitter = { '\n' };
 
         // Staged
-        string output = ExecuteProcessTerminal("git", "diff --name-only --staged");
+        string output = ExecuteProcessTerminal(GetGitPath(), "diff --name-only --staged");
         string[] lines = output.Split(splitter, StringSplitOptions.RemoveEmptyEntries);
         List<string> filesCandidates = new List<string>(lines);
 
         // Not staged
-        output = ExecuteProcessTerminal("git", "diff --name-only");
+        output = ExecuteProcessTerminal(GetGitPath(), "diff --name-only");
         lines = output.Split(splitter, StringSplitOptions.RemoveEmptyEntries);
         filesCandidates.AddRange(lines);
 
@@ -853,10 +865,10 @@ public class GitLocks : ScriptableObject
         foreach (string branch in branchesToCheck)
         {
             // Fetch
-            ExecuteProcessTerminal("git", "fetch origin " + branch);
+            ExecuteProcessTerminal(GetGitPath(), "fetch origin " + branch);
 
             // List all distant commits
-            string output = ExecuteProcessTerminal("git", "rev-list " + currentBranch + "..origin/" + branch);
+            string output = ExecuteProcessTerminal(GetGitPath(), "rev-list " + currentBranch + "..origin/" + branch);
             string[] lines = output.Split(splitter, StringSplitOptions.RemoveEmptyEntries);
             List<string> commits = new List<string>(lines);
 
@@ -864,7 +876,7 @@ public class GitLocks : ScriptableObject
             foreach (string commit in commits)
             {
                 // Add all files in commit to the list
-                string filesOutput = ExecuteProcessTerminal("git", "diff-tree --no-commit-id --name-only -r " + commit.Replace("\r", ""));
+                string filesOutput = ExecuteProcessTerminal(GetGitPath(), "diff-tree --no-commit-id --name-only -r " + commit.Replace("\r", ""));
                 string[] files = filesOutput.Split(splitter, StringSplitOptions.RemoveEmptyEntries);
 
                 foreach (string file in files)
@@ -902,7 +914,7 @@ public class GitLocks : ScriptableObject
     public static string GetCurrentBranch()
     {
         char[] splitter = { '\n' };
-        string currentBranch = ExecuteProcessTerminal("git", "rev-parse --abbrev-ref HEAD");
+        string currentBranch = ExecuteProcessTerminal(GetGitPath(), "rev-parse --abbrev-ref HEAD");
         currentBranch = currentBranch.Split(splitter)[0].Replace("\r", "");
         return currentBranch;
     }
@@ -935,7 +947,7 @@ public class GitLocks : ScriptableObject
             if (!EditorUtility.DisplayDialog("Git Lfs Locks Error", "Git lfs locks error :\n\n" + refreshCallbackError + "\n\nIf it's your first time using the tool, you should probably setup the credentials manager", "OK", "Setup credentials"))
             {
                 DebugLog("Setup credentials manager");
-                ExecuteProcessTerminalWithConsole("git", "config --global credential.helper manager");
+                ExecuteProcessTerminalWithConsole(GetGitPath(), "config --global credential.helper manager");
             }
 
             refreshCallbackError = null;

--- a/Editor/Scripts/GitLocksDisplay.cs
+++ b/Editor/Scripts/GitLocksDisplay.cs
@@ -526,7 +526,7 @@ public class GitLocksDisplay : EditorWindow
                 }
                 else
                 {
-                    GitLocks.ExecuteProcessTerminal("git", "log \"" + path + "\"", true);
+                    GitLocks.ExecuteProcessTerminal(GitLocks.GetGitPath(), "log \"" + path + "\"", true);
                 }
             }
         }

--- a/Editor/Scripts/GitLocksPreferences.cs
+++ b/Editor/Scripts/GitLocksPreferences.cs
@@ -67,6 +67,24 @@ public class GitLocksPreferences : SettingsProvider
             GUILayout.Space(5);
 
             EditorGUI.BeginChangeCheck();
+            string gitPath = EditorGUILayout.TextField(new GUIContent("Git binary path", "Absolute path to the git binary. Leave empty to use 'git' from PATH."), EditorPrefs.GetString("gitLocksGitPath", ""));
+            if (EditorGUI.EndChangeCheck())
+            {
+                EditorPrefs.SetString("gitLocksGitPath", gitPath);
+            }
+
+            GUILayout.Space(5);
+
+            EditorGUI.BeginChangeCheck();
+            string gitLfsPath = EditorGUILayout.TextField(new GUIContent("Git LFS binary path", "Absolute path to the git-lfs binary. Leave empty to use 'git-lfs' from PATH."), EditorPrefs.GetString("gitLocksGitLfsPath", ""));
+            if (EditorGUI.EndChangeCheck())
+            {
+                EditorPrefs.SetString("gitLocksGitLfsPath", gitLfsPath);
+            }
+
+            GUILayout.Space(5);
+
+            EditorGUI.BeginChangeCheck();
             int maxFilesNumPerRequest = EditorGUILayout.IntField(new GUIContent("Max number of files grouped per request"), EditorPrefs.GetInt("gitLocksMaxFilesNumPerRequest"));
             if (EditorGUI.EndChangeCheck())
             {
@@ -230,13 +248,13 @@ public class GitLocksPreferences : SettingsProvider
             EditorGUILayout.LabelField(new GUIContent("Your git version seems outdated (2.30.0 minimum), you may need to update it and then setup the Credentials Manager for the authentication to work properly"), EditorStyles.wordWrappedLabel);
             if (GUILayout.Button("Update Git for Windows"))
             {
-                GitLocks.ExecuteProcessTerminal("git", "update-git-for-windows", true);
+                GitLocks.ExecuteProcessTerminal(GitLocks.GetGitPath(), "update-git-for-windows", true);
             }
         }
 
         if (GUILayout.Button("Setup credentials manager (when using HTTPS)"))
         {
-            GitLocks.ExecuteProcessTerminalWithConsole("git", "config --local credential.helper manager");
+            GitLocks.ExecuteProcessTerminalWithConsole(GitLocks.GetGitPath(), "config --local credential.helper manager");
         }
 
         EditorGUI.indentLevel--;


### PR DESCRIPTION
This can be configured by starting Unity with a different `PATH`, but since it's just this plugin calling those binaries, this felt cleaner.

Found when running the plugin on my run-of-the-mill mac setup with git-lfs installed per user via homebrew.